### PR TITLE
Make email preview HTML generation the default (disabled with `email-preview: false`)

### DIFF
--- a/_extensions/quarto-email/quarto-email.lua
+++ b/_extensions/quarto-email/quarto-email.lua
@@ -402,9 +402,9 @@ function process_document(doc)
   local metadata_path_file = pandoc.path.join({dir, ".output_metadata.json"})
   io.open(metadata_path_file, "w"):write(metadata_str):close()
 
-  -- Write the `.email-preview.html` file to the working directory if the option is taken
-  if (meta_email_preview) then
-    quarto._quarto.file.write(pandoc.path.join({dir, "email-preview/email-preview.html"}), html_preview_body)
+  -- Write the `email-preview/index.html` file unless meta_email_preview is false
+  if meta_email_preview ~= false then
+    quarto._quarto.file.write(pandoc.path.join({dir, "email-preview/index.html"}), html_preview_body)
   end
 end
 

--- a/_extensions/quarto-email/quarto-email.lua
+++ b/_extensions/quarto-email/quarto-email.lua
@@ -13,7 +13,8 @@ Extension for generating email components needed for Posit Connect
    we must also include mime type information
 5. Generates a JSON file (.output_metadata.json) which contains specific email message
    components that Posit Connect expects for its own email generation code
-6. Produces a local `email-preview.html` file for previewing the HTML email
+6. Produces a local `index.html` file that contains the HTML email for previewing purposes
+   (this can be disabled by setting `email-preview: false` in the YAML header)
 --]]
 
 -- Get the file extension of any file residing on disk


### PR DESCRIPTION
The changes here make it so that the HTML message body is generated by default in the local `email-preview` directory. The name of the file has been changed to `index.html` for ease of access. This file generation can be suppressed with `email-preview: false` in a metadata block. 

Fixes: https://github.com/rich-iannone/quarto-email/issues/11