### PR TITLE
Add subject line to HTML preview

### DIFF
--- a/_extensions/quarto-email/quarto-email.lua
+++ b/_extensions/quarto-email/quarto-email.lua
@@ -328,7 +328,7 @@ function process_document(doc)
 
   -- Right after the </head> tag in `html_preview_body` we need to insert a subject line HTML string;
   -- this is the string to be inserted:
-  subject_html_preview = "<div style=\"background-color: white;\"><hr /><span style=\"margin-left: 25px\"><span style=\"font-weight: bold;\">Subject:</span> " .. subject .. "</span><hr /></div>"
+  subject_html_preview = "<div style=\"text-align: center; background-color: #fcfcfc; padding-top: 12px; font-size: large;\"><span style=\"margin-left: 25px\"><strong><span style=\"font-variant: small-caps;\">subject: </span></strong>" .. subject .. "</span><hr /></div>"
 
   -- insert `subject_html_preview` into `html_preview_body` at the aforementioned location
   html_preview_body = string.gsub(html_preview_body, "</head>", "</head>\n" .. subject_html_preview)

--- a/_extensions/quarto-email/quarto-email.lua
+++ b/_extensions/quarto-email/quarto-email.lua
@@ -326,6 +326,13 @@ function process_document(doc)
     connect_report_subscription_url
   )
 
+  -- Right after the </head> tag in `html_preview_body` we need to insert a subject line HTML string;
+  -- this is the string to be inserted:
+  subject_html_preview = "<div style=\"background-color: white;\"><hr /><span style=\"margin-left: 25px\"><span style=\"font-weight: bold;\">Subject:</span> " .. subject .. "</span><hr /></div>"
+
+  -- insert `subject_html_preview` into `html_preview_body` at the aforementioned location
+  html_preview_body = string.gsub(html_preview_body, "</head>", "</head>\n" .. subject_html_preview)
+
   -- For each of the <img> tags we need to create a Base64-encoded representation
   -- of the image and place that into the table `email_images` (keyed by `cid`)
 


### PR DESCRIPTION
This enhances the preview HTML file for the email message by inserting a subject line at the top of the email message body. The design here is to clearly show the text of the subject line without interfering with the layout of the HTML message content.

Here is a screenshot of the preview HTML in a browser:

<img width="1667" alt="subject-line-in-preview" src="https://github.com/rich-iannone/quarto-email/assets/5612024/427bdbf8-fc49-4816-9b83-d49fb7651205">

Fixes: #14 